### PR TITLE
CSP-1626 fixed source of legal entities

### DIFF
--- a/src/SFA.DAS.Employer.PR.Domain/Interfaces/IOuterApiClient.cs
+++ b/src/SFA.DAS.Employer.PR.Domain/Interfaces/IOuterApiClient.cs
@@ -12,6 +12,9 @@ public interface IOuterApiClient
     [Get("/accountusers/{userId}/accounts")]
     Task<GetEmployerUserAccountsResponse> GetUserAccounts([Path] string userId, [Query] string email, CancellationToken cancellationToken);
 
+    [Get("/employeraccounts/{accountId}/legalEntities")]
+    Task<GetAccountLegalEntitiesResponse> GetAccountLegalEntities([Path] long accountId, CancellationToken cancellationToken);
+
     [Get("/relationships/{accountId}")]
     Task<GetEmployerRelationshipsQueryResponse> GetEmployerRelationships([Path] long accountId, CancellationToken cancellationToken);
 

--- a/src/SFA.DAS.Employer.PR.Domain/Interfaces/IOuterApiClient.cs
+++ b/src/SFA.DAS.Employer.PR.Domain/Interfaces/IOuterApiClient.cs
@@ -13,7 +13,7 @@ public interface IOuterApiClient
     Task<GetEmployerUserAccountsResponse> GetUserAccounts([Path] string userId, [Query] string email, CancellationToken cancellationToken);
 
     [Get("/relationships/{accountId}")]
-    Task<GetEmployerRelationshipsQueryResponse> GetAccountLegalEntities([Path] long accountId, CancellationToken cancellationToken);
+    Task<GetEmployerRelationshipsQueryResponse> GetEmployerRelationships([Path] long accountId, CancellationToken cancellationToken);
 
     [Get("/providers")]
     Task<GetRegisteredProvidersResponse> GetRegisteredProviders(CancellationToken cancellationToken);

--- a/src/SFA.DAS.Employer.PR.Domain/Models/LegalEntity.cs
+++ b/src/SFA.DAS.Employer.PR.Domain/Models/LegalEntity.cs
@@ -1,11 +1,10 @@
 ﻿namespace SFA.DAS.Employer.PR.Domain.Models;
 
-public class AccountLegalEntity
+public class LegalEntity
 {
     public long Id { get; set; }
     public string PublicHashedId { get; set; } = null!;
-
     public string Name { get; set; } = null!;
     public long AccountId { get; set; }
-    public List<Permission> Permissions { get; set; } = [];
+    public List<ProviderPermission> ProviderPermissions { get; set; } = [];
 }

--- a/src/SFA.DAS.Employer.PR.Domain/Models/LegalEntity.cs
+++ b/src/SFA.DAS.Employer.PR.Domain/Models/LegalEntity.cs
@@ -6,5 +6,5 @@ public class LegalEntity
     public string PublicHashedId { get; set; } = null!;
     public string Name { get; set; } = null!;
     public long AccountId { get; set; }
-    public List<ProviderPermission> ProviderPermissions { get; set; } = [];
+    public List<ProviderPermission> Permissions { get; set; } = [];
 }

--- a/src/SFA.DAS.Employer.PR.Domain/Models/ProviderPermission.cs
+++ b/src/SFA.DAS.Employer.PR.Domain/Models/ProviderPermission.cs
@@ -1,6 +1,6 @@
 ﻿namespace SFA.DAS.Employer.PR.Domain.Models;
 
-public class Permission
+public class ProviderPermission
 {
     public long Ukprn { get; set; }
     public string ProviderName { get; set; } = null!;

--- a/src/SFA.DAS.Employer.PR.Domain/OuterApi/Responses/GetAccountLegalEntitiesResponse.cs
+++ b/src/SFA.DAS.Employer.PR.Domain/OuterApi/Responses/GetAccountLegalEntitiesResponse.cs
@@ -1,0 +1,5 @@
+﻿namespace SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
+
+public record GetAccountLegalEntitiesResponse(List<AccountLegalEntity> LegalEntities);
+
+public record AccountLegalEntity(string AccountLegalEntityName, string AccountLegalEntityPublicHashedId, long AccountLegalEntityId);

--- a/src/SFA.DAS.Employer.PR.Domain/OuterApi/Responses/GetEmployerRelationshipsQueryResponse.cs
+++ b/src/SFA.DAS.Employer.PR.Domain/OuterApi/Responses/GetEmployerRelationshipsQueryResponse.cs
@@ -2,4 +2,4 @@
 
 namespace SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
 
-public record GetEmployerRelationshipsQueryResponse(List<AccountLegalEntity> AccountLegalEntities);
+public record GetEmployerRelationshipsQueryResponse(List<LegalEntity> AccountLegalEntities);

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/AddPermissionsControllerTests/AddPermissionsControllerPostTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/AddPermissionsControllerTests/AddPermissionsControllerPostTests.cs
@@ -41,7 +41,7 @@ public class AddPermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<AddPermissionsSubmitViewViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
@@ -91,7 +91,7 @@ public class AddPermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<AddPermissionsSubmitViewViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
@@ -157,7 +157,7 @@ public class AddPermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<AddPermissionsSubmitViewViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
@@ -204,7 +204,7 @@ public class AddPermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<AddPermissionsSubmitViewViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
@@ -240,7 +240,7 @@ public class AddPermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<AddPermissionsSubmitViewViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/ChangePermissionsControllerTests/ChangePermissionsControllerPostTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/ChangePermissionsControllerTests/ChangePermissionsControllerPostTests.cs
@@ -42,7 +42,7 @@ public class ChangePermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<ChangePermissionsSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
@@ -85,7 +85,7 @@ public class ChangePermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<ChangePermissionsSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
@@ -138,7 +138,7 @@ public class ChangePermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<ChangePermissionsSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
@@ -207,7 +207,7 @@ public class ChangePermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<ChangePermissionsSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
@@ -264,7 +264,7 @@ public class ChangePermissionsControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<ChangePermissionsSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new()
+        ProviderPermission permission = new()
         { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerGetTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerGetTests.cs
@@ -60,15 +60,11 @@ public class SelectLegalEntityControllerGetTests
     public async Task Get_AccountWithSingleLegalEntity_RedirectsToSelectProvider(
         [Frozen] Mock<IOuterApiClient> outerApiClientMock,
         [Frozen] Mock<ISessionService> sessionServiceMock,
-        [Frozen] Mock<IEncodingService> encodingServiceMock,
         [Greedy] SelectLegalEntityController sut,
         AccountLegalEntity accountLegalEntity,
-        long accountLegalEntityId,
         string employerAccountId,
         CancellationToken cancellationToken)
     {
-        encodingServiceMock.Setup(e => e.Decode(accountLegalEntity.AccountLegalEntityPublicHashedId, EncodingType.PublicAccountLegalEntityId)).Returns(accountLegalEntityId);
-
         List<AccountLegalEntity> accountLegalEntities = [accountLegalEntity];
         outerApiClientMock.Setup(o => o.GetAccountLegalEntities(It.IsAny<long>(), cancellationToken)).ReturnsAsync(new GetAccountLegalEntitiesResponse(accountLegalEntities));
 
@@ -85,7 +81,7 @@ public class SelectLegalEntityControllerGetTests
         RedirectToRouteResult? redirectToRouteResult = result.As<RedirectToRouteResult>();
         redirectToRouteResult.RouteName.Should().Be(RouteNames.SelectTrainingProvider);
         sessionServiceMock.Verify(x => x.Set(It.Is<AddTrainingProvidersSessionModel>(
-            s => s.SelectedLegalEntityId == accountLegalEntityId &&
+            s => s.SelectedLegalEntityId == accountLegalEntity.AccountLegalEntityId &&
                  s.SelectedLegalName == accountLegalEntity.AccountLegalEntityName
         )), Times.AtLeastOnce);
     }

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerGetTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerGetTests.cs
@@ -28,21 +28,21 @@ public class SelectLegalEntityControllerGetTests
         string publicHashedId,
         CancellationToken cancellationToken)
     {
-        Permission permission = new() { Operations = new(), ProviderName = "provider name", Ukprn = 12345678 };
+        ProviderPermission permission = new() { Operations = new(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
-        List<Permission> permissions = new() { permission };
-        List<AccountLegalEntity> accountLegalEntities = new List<AccountLegalEntity>
+        List<ProviderPermission> permissions = new() { permission };
+        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
         {
-            new() {AccountId = accountId,Id=1 , Name=accountName, PublicHashedId = publicHashedId, Permissions = permissions},
-            new() {AccountId = 1123,Id=1, Name= $"{accountName}x", PublicHashedId = "12123232", Permissions = permissions}
+            new() {AccountId = accountId,Id=1 , Name=accountName, PublicHashedId = publicHashedId, ProviderPermissions = permissions},
+            new() {AccountId = 1123,Id=1, Name= $"{accountName}x", PublicHashedId = "12123232", ProviderPermissions = permissions}
         };
         var sessionServiceMock = new Mock<ISessionService>();
         sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
             .Returns(new AddTrainingProvidersSessionModel { EmployerAccountId = employerAccountId, AccountLegalEntities = accountLegalEntities });
 
         var outerApiClientMock = new Mock<IOuterApiClient>();
-        outerApiClientMock.Setup(o => o.GetAccountLegalEntities(It.IsAny<long>(), cancellationToken)).ReturnsAsync(new GetEmployerRelationshipsQueryResponse(accountLegalEntities));
+        outerApiClientMock.Setup(o => o.GetEmployerRelationships(It.IsAny<long>(), cancellationToken)).ReturnsAsync(new GetEmployerRelationshipsQueryResponse(accountLegalEntities));
 
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         SelectLegalEntityController sut = new(outerApiClientMock.Object, sessionServiceMock.Object, Mock.Of<IValidator<SelectLegalEntitiesSubmitViewModel>>(), Mock.Of<IEncodingService>())
@@ -74,26 +74,26 @@ public class SelectLegalEntityControllerGetTests
       string publicHashedId,
       CancellationToken cancellationToken)
     {
-        Permission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
+        ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
-        List<Permission> permissions = new List<Permission> { permission };
+        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
 
-        var firstLegalEntity = new AccountLegalEntity
+        var firstLegalEntity = new LegalEntity
         {
             AccountId = accountId,
             Id = 1,
             Name = accountName,
             PublicHashedId = publicHashedId,
-            Permissions = permissions
+            ProviderPermissions = permissions
         };
-        List<AccountLegalEntity> accountLegalEntities = new List<AccountLegalEntity>
+        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
         {
            firstLegalEntity
         };
 
         var outerApiClientMock = new Mock<IOuterApiClient>();
-        outerApiClientMock.Setup(o => o.GetAccountLegalEntities(It.IsAny<long>(), cancellationToken)).ReturnsAsync(new GetEmployerRelationshipsQueryResponse(accountLegalEntities));
+        outerApiClientMock.Setup(o => o.GetEmployerRelationships(It.IsAny<long>(), cancellationToken)).ReturnsAsync(new GetEmployerRelationshipsQueryResponse(accountLegalEntities));
 
 
 
@@ -128,7 +128,7 @@ public class SelectLegalEntityControllerGetTests
         CancellationToken cancellationToken
     )
     {
-        outerApiClientMock.Setup(o => o.GetAccountLegalEntities(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+        outerApiClientMock.Setup(o => o.GetEmployerRelationships(It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(employerRelationshipsQueryResponse);
         sessionServiceMock.Setup(s => s.Get<AddTrainingProvidersSessionModel>()).Returns((AddTrainingProvidersSessionModel)null!);
 

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerPostTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerPostTests.cs
@@ -37,7 +37,7 @@ public class SelectLegalEntityControllerPostTests
 
         sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.YourTrainingProviders, YourTrainingProvidersLink);
 
-        SelectLegalEntitiesSubmitViewModel submitModel = new() { LegalEntityId = accountLegalEntity.AccountLegalEntityPublicHashedId };
+        SelectLegalEntitiesSubmitViewModel submitModel = new() { LegalEntityPublicHashedId = accountLegalEntity.AccountLegalEntityPublicHashedId };
 
         /// Action
         var result = sut.Index(employerAccountId, submitModel);
@@ -56,7 +56,7 @@ public class SelectLegalEntityControllerPostTests
         List<AccountLegalEntity> accountLegalEntities,
         AccountLegalEntity selectedAccountLegalEntity)
     {
-        SelectLegalEntitiesSubmitViewModel submitModel = new SelectLegalEntitiesSubmitViewModel { LegalEntityId = selectedAccountLegalEntity.AccountLegalEntityPublicHashedId };
+        SelectLegalEntitiesSubmitViewModel submitModel = new SelectLegalEntitiesSubmitViewModel { LegalEntityPublicHashedId = selectedAccountLegalEntity.AccountLegalEntityPublicHashedId };
 
         validatorMock.Setup(v => v.Validate(It.IsAny<SelectLegalEntitiesSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerPostTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerPostTests.cs
@@ -37,13 +37,13 @@ public class SelectLegalEntityControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<SelectLegalEntitiesSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
+        ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
-        List<Permission> permissions = new List<Permission> { permission };
-        List<AccountLegalEntity> accountLegalEntities = new List<AccountLegalEntity>
+        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
+        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
         {
-            new() {AccountId = accountId,Id= accountLegalEntityId, Name=accountName, PublicHashedId = publicHashedId, Permissions = permissions}
+            new() {AccountId = accountId,Id= accountLegalEntityId, Name=accountName, PublicHashedId = publicHashedId, ProviderPermissions = permissions}
         };
 
         sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
@@ -75,14 +75,14 @@ public class SelectLegalEntityControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<SelectLegalEntitiesSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
+        ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
-        List<Permission> permissions = new List<Permission> { permission };
-        List<AccountLegalEntity> accountLegalEntities = new List<AccountLegalEntity>
+        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
+        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
         {
-            new() {AccountId = accountId,Id= accountLegalEntityId, Name=accountName, PublicHashedId = publicHashedId, Permissions = permissions},
-            new() {AccountId = 1,Name = "test", Permissions = permissions,PublicHashedId = "xyz"}
+            new() {AccountId = accountId,Id= accountLegalEntityId, Name=accountName, PublicHashedId = publicHashedId, ProviderPermissions = permissions},
+            new() {AccountId = 1,Name = "test", ProviderPermissions = permissions,PublicHashedId = "xyz"}
         };
 
         sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
@@ -114,14 +114,14 @@ public class SelectLegalEntityControllerPostTests
         validatorMock.Setup(v => v.Validate(It.IsAny<SelectLegalEntitiesSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        Permission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
+        ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
-        List<Permission> permissions = new List<Permission> { permission };
-        List<AccountLegalEntity> accountLegalEntities = new List<AccountLegalEntity>
+        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
+        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
         {
-            new() {AccountId = accountId,Id= accountLegalEntityId, Name=accountName, PublicHashedId = publicHashedId, Permissions = permissions},
-            new() {AccountId = 1,Name = "test", Permissions = permissions,PublicHashedId = "xyz"}
+            new() {AccountId = accountId,Id= accountLegalEntityId, Name=accountName, PublicHashedId = publicHashedId, ProviderPermissions = permissions},
+            new() {AccountId = 1,Name = "test", ProviderPermissions = permissions,PublicHashedId = "xyz"}
         };
 
         sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
@@ -156,13 +156,13 @@ public class SelectLegalEntityControllerPostTests
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
 
-        Permission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
+        ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
-        List<Permission> permissions = new List<Permission> { permission };
-        List<AccountLegalEntity> accountLegalEntities = new List<AccountLegalEntity>
+        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
+        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
         {
-            new() {AccountId = accountId,Id=1 , Name=accountName, PublicHashedId = publicHashedId, Permissions = permissions}
+            new() {AccountId = accountId,Id=1 , Name=accountName, PublicHashedId = publicHashedId, ProviderPermissions = permissions}
         };
 
         sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerPostTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerPostTests.cs
@@ -110,4 +110,20 @@ public class SelectLegalEntityControllerPostTests
         viewModel!.LegalEntities.Count.Should().Be(accountLegalEntities.Count);
         sessionServiceMock.Verify(s => s.Set(It.IsAny<AddTrainingProvidersSessionModel>()), Times.Never);
     }
+
+    [Test, MoqAutoData]
+    public void Post_SessionModelNotSet_RedirectsToYourProvidersPage(
+        [Frozen] Mock<ISessionService> sessionServiceMock,
+        [Greedy] SelectLegalEntityController sut,
+        string employerAccountId)
+    {
+        SelectLegalEntitiesSubmitViewModel submitModel = new();
+
+        sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>()).Returns(() => null);
+
+        var result = sut.Index(employerAccountId, submitModel);
+
+        result.As<RedirectToRouteResult>().Should().NotBeNull();
+        result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.YourTrainingProviders);
+    }
 }

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerPostTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectLegalEntityControllerTests/SelectLegalEntityControllerPostTests.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Employer.PR.Domain.Models;
+using SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
 using SFA.DAS.Employer.PR.Web.Authentication;
 using SFA.DAS.Employer.PR.Web.Controllers;
 using SFA.DAS.Employer.PR.Web.Infrastructure;
@@ -23,35 +24,22 @@ public class SelectLegalEntityControllerPostTests
         [Frozen] Mock<ISessionService> sessionServiceMock,
         [Greedy] SelectLegalEntityController sut,
         string employerAccountId,
-        int accountId,
-        string accountName,
-        string publicHashedId)
+        AccountLegalEntity accountLegalEntity)
     {
-        var accountLegalEntityId = 1;
-        SelectLegalEntitiesSubmitViewModel submitModel = new SelectLegalEntitiesSubmitViewModel
-        {
-            LegalEntityId = accountLegalEntityId,
-            LegalName = "legal name"
-        };
-
         validatorMock.Setup(v => v.Validate(It.IsAny<SelectLegalEntitiesSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
-        permission.Operations.Add(Operation.CreateCohort);
-
-        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
-        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
-        {
-            new() {AccountId = accountId,Id= accountLegalEntityId, Name=accountName, PublicHashedId = publicHashedId, ProviderPermissions = permissions}
-        };
-
+        List<AccountLegalEntity> accountLegalEntities = [accountLegalEntity];
         sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
             .Returns(new AddTrainingProvidersSessionModel { AccountLegalEntities = accountLegalEntities });
 
         sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
 
         sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.YourTrainingProviders, YourTrainingProvidersLink);
+
+        SelectLegalEntitiesSubmitViewModel submitModel = new() { LegalEntityId = accountLegalEntity.AccountLegalEntityPublicHashedId };
+
+        /// Action
         var result = sut.Index(employerAccountId, submitModel);
 
         RedirectToRouteResult? redirectToRouteResult = result.As<RedirectToRouteResult>();
@@ -65,89 +53,39 @@ public class SelectLegalEntityControllerPostTests
         [Frozen] Mock<ISessionService> sessionServiceMock,
         [Greedy] SelectLegalEntityController sut,
         string employerAccountId,
-        int accountId,
-        string accountName,
-        string publicHashedId)
+        List<AccountLegalEntity> accountLegalEntities,
+        AccountLegalEntity selectedAccountLegalEntity)
     {
-        var accountLegalEntityId = 1;
-        SelectLegalEntitiesSubmitViewModel submitModel = new SelectLegalEntitiesSubmitViewModel { LegalEntityId = accountLegalEntityId };
+        SelectLegalEntitiesSubmitViewModel submitModel = new SelectLegalEntitiesSubmitViewModel { LegalEntityId = selectedAccountLegalEntity.AccountLegalEntityPublicHashedId };
 
         validatorMock.Setup(v => v.Validate(It.IsAny<SelectLegalEntitiesSubmitViewModel>())).Returns(new ValidationResult());
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-        ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
-        permission.Operations.Add(Operation.CreateCohort);
-
-        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
-        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
-        {
-            new() {AccountId = accountId,Id= accountLegalEntityId, Name=accountName, PublicHashedId = publicHashedId, ProviderPermissions = permissions},
-            new() {AccountId = 1,Name = "test", ProviderPermissions = permissions,PublicHashedId = "xyz"}
-        };
+        accountLegalEntities.Add(selectedAccountLegalEntity);
 
         sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
             .Returns(new AddTrainingProvidersSessionModel { AccountLegalEntities = accountLegalEntities });
 
         sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
 
-
         sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.YourTrainingProviders, YourTrainingProvidersLink);
-        var result = sut.Index(employerAccountId, submitModel);
-        sessionServiceMock.Verify(s => s.Set(It.Is<AddTrainingProvidersSessionModel>(s => s.SelectedLegalEntityId == accountLegalEntityId && s.SelectedLegalName == accountName)), Times.Once);
+
+        /// Action
+        sut.Index(employerAccountId, submitModel);
+
+        sessionServiceMock.Verify(s => s.Set(It.Is<AddTrainingProvidersSessionModel>(s => s.SelectedLegalEntityId == selectedAccountLegalEntity.AccountLegalEntityId && s.SelectedLegalName == selectedAccountLegalEntity.AccountLegalEntityName)), Times.Once);
     }
 
     [Test, MoqAutoData]
-
-    public void Post_Validated_RedirectIfEmployerAccountDoesNotMatch(
+    public void Post_ValidationFailed_ReturnsExpectedModel(
         [Frozen] Mock<IValidator<SelectLegalEntitiesSubmitViewModel>> validatorMock,
         [Frozen] Mock<ISessionService> sessionServiceMock,
         [Greedy] SelectLegalEntityController sut,
-        string employerAccountId,
-        int accountId,
-        string accountName,
-        string publicHashedId,
-        CancellationToken cancellationToken)
+        List<AccountLegalEntity> accountLegalEntities,
+        string employerAccountId)
     {
-        var accountLegalEntityId = 1;
-        SelectLegalEntitiesSubmitViewModel submitModel = new SelectLegalEntitiesSubmitViewModel { LegalEntityId = accountLegalEntityId };
+        SelectLegalEntitiesSubmitViewModel submitModel = new();
 
-        validatorMock.Setup(v => v.Validate(It.IsAny<SelectLegalEntitiesSubmitViewModel>())).Returns(new ValidationResult());
-        ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
-
-        ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
-        permission.Operations.Add(Operation.CreateCohort);
-
-        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
-        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
-        {
-            new() {AccountId = accountId,Id= accountLegalEntityId, Name=accountName, PublicHashedId = publicHashedId, ProviderPermissions = permissions},
-            new() {AccountId = 1,Name = "test", ProviderPermissions = permissions,PublicHashedId = "xyz"}
-        };
-
-        sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
-            .Returns(new AddTrainingProvidersSessionModel { AccountLegalEntities = accountLegalEntities });
-
-        sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
-
-
-        sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.YourTrainingProviders, YourTrainingProvidersLink);
-        var result = sut.Index(employerAccountId, submitModel);
-
-        sessionServiceMock.Verify(s => s.Set(It.Is<AddTrainingProvidersSessionModel>(s => s.SelectedLegalEntityId == accountLegalEntityId && s.SelectedLegalName == accountName)), Times.Once);
-    }
-
-
-    [Test, MoqAutoData]
-    public void Post_ValidatedAndFailed_ReturnsExpectedModel(
-        [Frozen] Mock<IValidator<SelectLegalEntitiesSubmitViewModel>> validatorMock,
-        [Frozen] Mock<ISessionService> sessionServiceMock,
-        [Greedy] SelectLegalEntityController sut,
-        string employerAccountId,
-        int accountId,
-        string accountName,
-        string publicHashedId)
-    {
-        SelectLegalEntitiesSubmitViewModel submitModel = new SelectLegalEntitiesSubmitViewModel();
         validatorMock.Setup(m => m.Validate(It.IsAny<SelectLegalEntitiesSubmitViewModel>())).Returns(new ValidationResult(new List<ValidationFailure>()
         {
             new("TestField","Test Message") { ErrorCode = "1001"}
@@ -155,18 +93,10 @@ public class SelectLegalEntityControllerPostTests
 
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
 
-
         ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
-        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
-        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
-        {
-            new() {AccountId = accountId,Id=1 , Name=accountName, PublicHashedId = publicHashedId, ProviderPermissions = permissions}
-        };
-
         sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
-
 
         sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
             .Returns(new AddTrainingProvidersSessionModel { AccountLegalEntities = accountLegalEntities });
@@ -177,11 +107,7 @@ public class SelectLegalEntityControllerPostTests
         ViewResult? viewResult = result.As<ViewResult>();
         SelectLegalEntitiesViewModel? viewModel = viewResult.Model as SelectLegalEntitiesViewModel;
 
-        viewModel!.LegalEntities.Count.Should().Be(1);
-        LegalEntityModel actualLegalEntity = viewModel.LegalEntities.First();
-        actualLegalEntity.AccountId.Should().Be(accountId);
-        actualLegalEntity.Name.Should().Be(accountName);
-        actualLegalEntity.LegalEntityPublicHashedId.Should().Be(publicHashedId);
+        viewModel!.LegalEntities.Count.Should().Be(accountLegalEntities.Count);
         sessionServiceMock.Verify(s => s.Set(It.IsAny<AddTrainingProvidersSessionModel>()), Times.Never);
     }
 }

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectTrainingProviderControllerTests/SelectTrainingProviderControllerGetTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectTrainingProviderControllerTests/SelectTrainingProviderControllerGetTests.cs
@@ -1,7 +1,7 @@
 ﻿using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Employer.PR.Domain.Interfaces;
-using SFA.DAS.Employer.PR.Domain.Models;
+using SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
 using SFA.DAS.Employer.PR.Web.Authentication;
 using SFA.DAS.Employer.PR.Web.Controllers;
 using SFA.DAS.Employer.PR.Web.Infrastructure;
@@ -42,6 +42,7 @@ public class SelectTrainingProviderControllerGetTests
 
     [Test, MoqAutoData]
     public void SelectTrainingProviderGet_SingleLegalEntity_SetsBackLinkToExpected(
+        AccountLegalEntity accountLegalEntity,
         string employerAccountId,
         long legalEntityId,
         string legalName
@@ -55,7 +56,7 @@ public class SelectTrainingProviderControllerGetTests
                 EmployerAccountId = employerAccountId,
                 SelectedLegalEntityId = legalEntityId,
                 SelectedLegalName = legalName,
-                AccountLegalEntities = new List<LegalEntity> { new LegalEntity() }
+                AccountLegalEntities = [accountLegalEntity]
             });
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         SelectTrainingProviderController sut = new(Mock.Of<IOuterApiClient>(), sessionServiceMock.Object,
@@ -74,6 +75,7 @@ public class SelectTrainingProviderControllerGetTests
 
     [Test, MoqAutoData]
     public void SelectTrainingProviderGet_MultipleLegalEntity_SetsBackLinkToExpected(
+        List<AccountLegalEntity> accountLegalEntities,
         string employerAccountId,
         long legalEntityId,
         string legalName
@@ -87,7 +89,7 @@ public class SelectTrainingProviderControllerGetTests
                 EmployerAccountId = employerAccountId,
                 SelectedLegalEntityId = legalEntityId,
                 SelectedLegalName = legalName,
-                AccountLegalEntities = new List<LegalEntity> { new LegalEntity(), new LegalEntity() }
+                AccountLegalEntities = accountLegalEntities
             });
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         SelectTrainingProviderController sut = new(Mock.Of<IOuterApiClient>(), sessionServiceMock.Object, Mock.Of<IEncodingService>(), Mock.Of<IValidator<SelectTrainingProviderSubmitModel>>())

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectTrainingProviderControllerTests/SelectTrainingProviderControllerGetTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectTrainingProviderControllerTests/SelectTrainingProviderControllerGetTests.cs
@@ -55,7 +55,7 @@ public class SelectTrainingProviderControllerGetTests
                 EmployerAccountId = employerAccountId,
                 SelectedLegalEntityId = legalEntityId,
                 SelectedLegalName = legalName,
-                AccountLegalEntities = new List<AccountLegalEntity> { new AccountLegalEntity() }
+                AccountLegalEntities = new List<LegalEntity> { new LegalEntity() }
             });
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         SelectTrainingProviderController sut = new(Mock.Of<IOuterApiClient>(), sessionServiceMock.Object,
@@ -87,7 +87,7 @@ public class SelectTrainingProviderControllerGetTests
                 EmployerAccountId = employerAccountId,
                 SelectedLegalEntityId = legalEntityId,
                 SelectedLegalName = legalName,
-                AccountLegalEntities = new List<AccountLegalEntity> { new AccountLegalEntity(), new AccountLegalEntity() }
+                AccountLegalEntities = new List<LegalEntity> { new LegalEntity(), new LegalEntity() }
             });
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         SelectTrainingProviderController sut = new(Mock.Of<IOuterApiClient>(), sessionServiceMock.Object, Mock.Of<IEncodingService>(), Mock.Of<IValidator<SelectTrainingProviderSubmitModel>>())

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectTrainingProviderControllerTests/SelectTrainingProviderControllerPostTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectTrainingProviderControllerTests/SelectTrainingProviderControllerPostTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System.Net;
+using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Mvc;
 using RestEase;
@@ -14,7 +15,6 @@ using SFA.DAS.Employer.PR.Web.Models.Session;
 using SFA.DAS.Employer.PR.Web.UnitTests.TestHelpers;
 using SFA.DAS.Encoding;
 using SFA.DAS.Testing.AutoFixture;
-using System.Net;
 
 namespace SFA.DAS.Employer.PR.Web.UnitTests.Controllers.SelectTrainingProviderControllerTests;
 public class SelectTrainingProviderControllerPostTests
@@ -29,6 +29,7 @@ public class SelectTrainingProviderControllerPostTests
         int ukprn,
         string name,
         long accountLegalEntityId,
+        List<AccountLegalEntity> accountLegalEntities,
         CancellationToken cancellationToken)
     {
         var sessionServiceMock = new Mock<ISessionService>();
@@ -36,7 +37,7 @@ public class SelectTrainingProviderControllerPostTests
             .Returns(new AddTrainingProvidersSessionModel
             {
                 SelectedLegalEntityId = accountLegalEntityId,
-                AccountLegalEntities = new() { new LegalEntity() },
+                AccountLegalEntities = accountLegalEntities,
                 EmployerAccountId = employerAccountId
             });
 
@@ -79,6 +80,7 @@ public class SelectTrainingProviderControllerPostTests
         int ukprn,
         string name,
         long accountLegalEntityId,
+        List<AccountLegalEntity> accountLegalEntities,
         CancellationToken cancellationToken)
     {
         var sessionServiceMock = new Mock<ISessionService>();
@@ -89,7 +91,7 @@ public class SelectTrainingProviderControllerPostTests
                 .Returns(new AddTrainingProvidersSessionModel
                 {
                     SelectedLegalEntityId = accountLegalEntityId,
-                    AccountLegalEntities = new() { new LegalEntity() },
+                    AccountLegalEntities = accountLegalEntities,
                     EmployerAccountId = employerAccountIdOther
                 });
         }
@@ -130,13 +132,15 @@ public class SelectTrainingProviderControllerPostTests
     [Test, MoqAutoData]
     public async Task Post_ValidatedAndFailed_ReturnsExpectedModel(
         Mock<IValidator<SelectTrainingProviderSubmitModel>> validatorMock,
+        AccountLegalEntity accountLegalEntity,
         string employerAccountId,
         CancellationToken cancellationToken)
     {
+        List<AccountLegalEntity> accountLegalEntities = [accountLegalEntity];
         var sessionServiceMock = new Mock<ISessionService>();
         var outerApiClientMock = new Mock<IOuterApiClient>();
         sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
-            .Returns(new AddTrainingProvidersSessionModel { AccountLegalEntities = new() { new LegalEntity() }, EmployerAccountId = employerAccountId });
+            .Returns(new AddTrainingProvidersSessionModel { AccountLegalEntities = accountLegalEntities, EmployerAccountId = employerAccountId });
 
         SelectTrainingProviderSubmitModel submitModel = new SelectTrainingProviderSubmitModel();
         validatorMock.Setup(m => m.Validate(It.IsAny<SelectTrainingProviderSubmitModel>())).Returns(new ValidationResult(new List<ValidationFailure>()
@@ -167,6 +171,7 @@ public class SelectTrainingProviderControllerPostTests
         int ukprn,
         string name,
         long accountLegalEntityId,
+        List<AccountLegalEntity> accountLegalEntities,
         CancellationToken cancellationToken)
     {
         var sessionServiceMock = new Mock<ISessionService>();
@@ -175,7 +180,7 @@ public class SelectTrainingProviderControllerPostTests
             {
                 SelectedLegalEntityId = accountLegalEntityId,
                 EmployerAccountId = employerAccountId,
-                AccountLegalEntities = new() { new LegalEntity() }
+                AccountLegalEntities = accountLegalEntities
             });
 
         var outerApiClientMock = new Mock<IOuterApiClient>();
@@ -221,6 +226,7 @@ public class SelectTrainingProviderControllerPostTests
        int ukprn,
        string name,
        long accountLegalEntityId,
+       List<AccountLegalEntity> accountLegalEntities,
        CancellationToken cancellationToken)
     {
         var sessionServiceMock = new Mock<ISessionService>();
@@ -229,7 +235,7 @@ public class SelectTrainingProviderControllerPostTests
             {
                 SelectedLegalEntityId = accountLegalEntityId,
                 EmployerAccountId = employerAccountId,
-                AccountLegalEntities = new() { new LegalEntity() }
+                AccountLegalEntities = accountLegalEntities
             });
 
         var outerApiClientMock = new Mock<IOuterApiClient>();

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectTrainingProviderControllerTests/SelectTrainingProviderControllerPostTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/SelectTrainingProviderControllerTests/SelectTrainingProviderControllerPostTests.cs
@@ -36,7 +36,7 @@ public class SelectTrainingProviderControllerPostTests
             .Returns(new AddTrainingProvidersSessionModel
             {
                 SelectedLegalEntityId = accountLegalEntityId,
-                AccountLegalEntities = new() { new AccountLegalEntity() },
+                AccountLegalEntities = new() { new LegalEntity() },
                 EmployerAccountId = employerAccountId
             });
 
@@ -89,7 +89,7 @@ public class SelectTrainingProviderControllerPostTests
                 .Returns(new AddTrainingProvidersSessionModel
                 {
                     SelectedLegalEntityId = accountLegalEntityId,
-                    AccountLegalEntities = new() { new AccountLegalEntity() },
+                    AccountLegalEntities = new() { new LegalEntity() },
                     EmployerAccountId = employerAccountIdOther
                 });
         }
@@ -136,7 +136,7 @@ public class SelectTrainingProviderControllerPostTests
         var sessionServiceMock = new Mock<ISessionService>();
         var outerApiClientMock = new Mock<IOuterApiClient>();
         sessionServiceMock.Setup(x => x.Get<AddTrainingProvidersSessionModel>())
-            .Returns(new AddTrainingProvidersSessionModel { AccountLegalEntities = new() { new AccountLegalEntity() }, EmployerAccountId = employerAccountId });
+            .Returns(new AddTrainingProvidersSessionModel { AccountLegalEntities = new() { new LegalEntity() }, EmployerAccountId = employerAccountId });
 
         SelectTrainingProviderSubmitModel submitModel = new SelectTrainingProviderSubmitModel();
         validatorMock.Setup(m => m.Validate(It.IsAny<SelectTrainingProviderSubmitModel>())).Returns(new ValidationResult(new List<ValidationFailure>()
@@ -175,7 +175,7 @@ public class SelectTrainingProviderControllerPostTests
             {
                 SelectedLegalEntityId = accountLegalEntityId,
                 EmployerAccountId = employerAccountId,
-                AccountLegalEntities = new() { new AccountLegalEntity() }
+                AccountLegalEntities = new() { new LegalEntity() }
             });
 
         var outerApiClientMock = new Mock<IOuterApiClient>();
@@ -229,7 +229,7 @@ public class SelectTrainingProviderControllerPostTests
             {
                 SelectedLegalEntityId = accountLegalEntityId,
                 EmployerAccountId = employerAccountId,
-                AccountLegalEntities = new() { new AccountLegalEntity() }
+                AccountLegalEntities = new() { new LegalEntity() }
             });
 
         var outerApiClientMock = new Mock<IOuterApiClient>();

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/YourTrainingProvidersControllerTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/YourTrainingProvidersControllerTests.cs
@@ -126,17 +126,17 @@ public class YourTrainingProvidersControllerTests
             new()
             {
                 AccountId = accountId, Id = 1, Name = accountNameExpectedThird, PublicHashedId = "KJGH",
-                ProviderPermissions = new List<ProviderPermission> {permissionOther}
+                Permissions = new List<ProviderPermission> {permissionOther}
             },
             new()
             {
                 AccountId = accountId, Id=2, Name = accountNameExpectedFirst, PublicHashedId = publicHashedId,
-                ProviderPermissions = permissions
+                Permissions = permissions
             },
             new()
             {
                 AccountId = accountId, Id = 1, Name = accountNameExpectedSecond, PublicHashedId = "AVBC",
-                ProviderPermissions = new List<ProviderPermission> {permissionOther}
+                Permissions = new List<ProviderPermission> {permissionOther}
             },
         };
 
@@ -402,14 +402,14 @@ public class YourTrainingProvidersControllerTests
             new()
             {
                 AccountId = accountId, Id = 1, Name = accountName, PublicHashedId = publicHashedId,
-                ProviderPermissions = permissions
+                Permissions = permissions
             }
         };
 
         if (multipleAccounts)
         {
             accountLegalEntities.Add(new LegalEntity
-            { AccountId = 1234, Id = 2, Name = "name 2", PublicHashedId = "AFC", ProviderPermissions = permissions });
+            { AccountId = 1234, Id = 2, Name = "name 2", PublicHashedId = "AFC", Permissions = permissions });
         }
 
         GetEmployerRelationshipsQueryResponse response = new GetEmployerRelationshipsQueryResponse(accountLegalEntities);

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/YourTrainingProvidersControllerTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/YourTrainingProvidersControllerTests.cs
@@ -33,7 +33,7 @@ public class YourTrainingProvidersControllerTests
      )
     {
         encodingServiceMock.Setup(e => e.Decode(employerAccountId, EncodingType.AccountId)).Returns(accountId);
-        outerApiMock.Setup(o => o.GetAccountLegalEntities(accountId, It.IsAny<CancellationToken>()))
+        outerApiMock.Setup(o => o.GetEmployerRelationships(accountId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
@@ -43,7 +43,7 @@ public class YourTrainingProvidersControllerTests
         };
 
         var result = sut.Index(employerAccountId, new CancellationToken());
-        outerApiMock.Verify(o => o.GetAccountLegalEntities(accountId, It.IsAny<CancellationToken>()), Times.Once);
+        outerApiMock.Verify(o => o.GetEmployerRelationships(accountId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -70,10 +70,10 @@ public class YourTrainingProvidersControllerTests
         };
 
 
-        Permission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
+        ProviderPermission permission = new() { Operations = new List<Operation>(), ProviderName = "provider name", Ukprn = 12345678 };
         permission.Operations.Add(Operation.CreateCohort);
 
-        List<Permission> permissions = new List<Permission> { permission };
+        List<ProviderPermission> permissions = new List<ProviderPermission> { permission };
         SetupControllerAndClasses(outerApiMock, accountId, accountName, publicHashedId, permissions, sut, false);
         Task<IActionResult> result = sut.Index(employerAccountId, new CancellationToken());
 
@@ -110,10 +110,10 @@ public class YourTrainingProvidersControllerTests
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, roleToTest);
 
 
-        Permission permissionOther = new() { Operations = new List<Operation>() { Operation.CreateCohort }, ProviderName = "provider", Ukprn = 12345678 };
+        ProviderPermission permissionOther = new() { Operations = new List<Operation>() { Operation.CreateCohort }, ProviderName = "provider", Ukprn = 12345678 };
         permissionOther.Operations.Add(Operation.CreateCohort);
 
-        List<Permission> permissions = new List<Permission>
+        List<ProviderPermission> permissions = new List<ProviderPermission>
         {
             new() { Operations = new List<Operation>{ Operation.CreateCohort }, ProviderName = providerNameExpectedThird, Ukprn = 12345678 },
             new() { Operations = new List<Operation>{ Operation.CreateCohort }, ProviderName = providerNameExpectedFirst, Ukprn = 12345679 },
@@ -121,28 +121,28 @@ public class YourTrainingProvidersControllerTests
         };
 
 
-        List<AccountLegalEntity> accountLegalEntities = new List<AccountLegalEntity>
+        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
         {
             new()
             {
                 AccountId = accountId, Id = 1, Name = accountNameExpectedThird, PublicHashedId = "KJGH",
-                Permissions = new List<Permission> {permissionOther}
+                ProviderPermissions = new List<ProviderPermission> {permissionOther}
             },
             new()
             {
                 AccountId = accountId, Id=2, Name = accountNameExpectedFirst, PublicHashedId = publicHashedId,
-                Permissions = permissions
+                ProviderPermissions = permissions
             },
             new()
             {
                 AccountId = accountId, Id = 1, Name = accountNameExpectedSecond, PublicHashedId = "AVBC",
-                Permissions = new List<Permission> {permissionOther}
+                ProviderPermissions = new List<ProviderPermission> {permissionOther}
             },
         };
 
         encodingServiceMock.Setup(e => e.Decode(employerAccountId, EncodingType.AccountId)).Returns(accountId);
 
-        outerApiMock.Setup(o => o.GetAccountLegalEntities(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+        outerApiMock.Setup(o => o.GetEmployerRelationships(It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetEmployerRelationshipsQueryResponse(accountLegalEntities));
 
         YourTrainingProvidersController sut = new(outerApiMock.Object, Mock.Of<ISessionService>(), encodingServiceMock.Object)
@@ -189,7 +189,7 @@ public class YourTrainingProvidersControllerTests
         var accountName = "account name";
         var publicHashedId = "12123232";
 
-        var permission = new Permission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
+        var permission = new ProviderPermission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
         if (operation1 != null) permission.Operations.Add(operation1.Value);
         if (operation2 != null) permission.Operations.Add(operation2.Value);
 
@@ -200,7 +200,7 @@ public class YourTrainingProvidersControllerTests
         {
             ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } }
         };
-        var permissions = new List<Permission> { permission };
+        var permissions = new List<ProviderPermission> { permission };
         SetupControllerAndClasses(outerApiMock, accountId, accountName, publicHashedId, permissions, sut, false);
 
         sut.AddUrlHelperMock().AddUrlForRoute(RouteNames.ChangePermissions, ChangePermissionsLink);
@@ -239,7 +239,7 @@ public class YourTrainingProvidersControllerTests
 
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
-        var permissions = new List<Permission>();
+        var permissions = new List<ProviderPermission>();
         SetupControllerAndClasses(outerApiMock, accountId, accountName, publicHashedId, permissions, sut, false);
 
         var result = sut.Index(employerAccountId, new CancellationToken());
@@ -264,13 +264,13 @@ public class YourTrainingProvidersControllerTests
         var accountName = "account name";
         var publicHashedId = "12123232";
 
-        var permission = new Permission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
+        var permission = new ProviderPermission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
         permission.Operations.Add(Operation.CreateCohort);
         permission.Operations.Add(Operation.Recruitment);
 
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
-        var permissions = new List<Permission> { permission };
+        var permissions = new List<ProviderPermission> { permission };
         SetupControllerAndClasses(outerApiMock, accountId, accountName, publicHashedId, permissions, sut, false);
 
         var result = sut.Index(employerAccountId, new CancellationToken());
@@ -290,13 +290,13 @@ public class YourTrainingProvidersControllerTests
         var accountName = "account name";
         var publicHashedId = "12123232";
 
-        var permission = new Permission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
+        var permission = new ProviderPermission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
         permission.Operations.Add(Operation.CreateCohort);
         permission.Operations.Add(Operation.Recruitment);
 
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
-        var permissions = new List<Permission> { permission };
+        var permissions = new List<ProviderPermission> { permission };
         SetupControllerAndClasses(outerApiMock, accountId, accountName, publicHashedId, permissions, sut, true);
 
         var result = sut.Index(employerAccountId, new CancellationToken());
@@ -322,7 +322,7 @@ public class YourTrainingProvidersControllerTests
         var accountName = "account name";
         var publicHashedId = "12123232";
 
-        var permission = new Permission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
+        var permission = new ProviderPermission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
         permission.Operations.Add(Operation.CreateCohort);
         permission.Operations.Add(Operation.Recruitment);
 
@@ -332,7 +332,7 @@ public class YourTrainingProvidersControllerTests
 
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
-        var permissions = new List<Permission> { permission };
+        var permissions = new List<ProviderPermission> { permission };
         SetupControllerAndClasses(outerApiMock, accountId, accountName, publicHashedId, permissions, sut, false);
 
         Mock<ITempDataDictionary> tempDataMock = new();
@@ -366,7 +366,7 @@ public class YourTrainingProvidersControllerTests
         var accountName = "account name";
         var publicHashedId = "12123232";
 
-        var permission = new Permission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
+        var permission = new ProviderPermission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
         permission.Operations.Add(Operation.CreateCohort);
         permission.Operations.Add(Operation.Recruitment);
 
@@ -376,7 +376,7 @@ public class YourTrainingProvidersControllerTests
 
         ClaimsPrincipal user = UsersForTesting.GetUserWithClaims(employerAccountId, EmployerUserRole.Owner);
         sut.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
-        var permissions = new List<Permission> { permission };
+        var permissions = new List<ProviderPermission> { permission };
         SetupControllerAndClasses(outerApiMock, accountId, accountName, publicHashedId, permissions, sut, false);
 
         Mock<ITempDataDictionary> tempDataMock = new();
@@ -395,26 +395,26 @@ public class YourTrainingProvidersControllerTests
     }
 
     private static void SetupControllerAndClasses(Mock<IOuterApiClient> outerApiMock, int accountId, string accountName,
-        string publicHashedId, List<Permission> permissions, YourTrainingProvidersController sut, bool multipleAccounts)
+        string publicHashedId, List<ProviderPermission> permissions, YourTrainingProvidersController sut, bool multipleAccounts)
     {
-        List<AccountLegalEntity> accountLegalEntities = new List<AccountLegalEntity>
+        List<LegalEntity> accountLegalEntities = new List<LegalEntity>
         {
             new()
             {
                 AccountId = accountId, Id = 1, Name = accountName, PublicHashedId = publicHashedId,
-                Permissions = permissions
+                ProviderPermissions = permissions
             }
         };
 
         if (multipleAccounts)
         {
-            accountLegalEntities.Add(new AccountLegalEntity
-            { AccountId = 1234, Id = 2, Name = "name 2", PublicHashedId = "AFC", Permissions = permissions });
+            accountLegalEntities.Add(new LegalEntity
+            { AccountId = 1234, Id = 2, Name = "name 2", PublicHashedId = "AFC", ProviderPermissions = permissions });
         }
 
         GetEmployerRelationshipsQueryResponse response = new GetEmployerRelationshipsQueryResponse(accountLegalEntities);
 
-        outerApiMock.Setup(o => o.GetAccountLegalEntities(accountId, It.IsAny<CancellationToken>()))
+        outerApiMock.Setup(o => o.GetEmployerRelationships(accountId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         Mock<ITempDataDictionary> tempDataMock = new();

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/AccountLegalEntityViewModelTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/AccountLegalEntityViewModelTests.cs
@@ -1,0 +1,18 @@
+﻿using AutoFixture.NUnit3;
+using SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
+using SFA.DAS.Employer.PR.Web.Models;
+
+namespace SFA.DAS.Employer.PR.Web.UnitTests.Models;
+
+public class AccountLegalEntityViewModelTests
+{
+    [Test, AutoData]
+    public void Operator_ConvertsFrom_AccountLegalEntity(AccountLegalEntity source)
+    {
+        /// Action
+        AccountLegalEntityViewModel sut = source;
+
+        sut.Name.Should().Be(source.AccountLegalEntityName);
+        sut.Id.Should().Be(source.AccountLegalEntityPublicHashedId);
+    }
+}

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/LegalEntityModelTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/LegalEntityModelTests.cs
@@ -6,7 +6,7 @@ namespace SFA.DAS.Employer.PR.Web.UnitTests.Models;
 public class LegalEntityModelTests
 {
     [Test, AutoData]
-    public void Operator_ConvertsTo_LegalEntityModel(AccountLegalEntity sut)
+    public void Operator_ConvertsTo_LegalEntityModel(LegalEntity sut)
     {
         LegalEntityModel model = sut;
         sut.Should().BeEquivalentTo(model, options => options.ExcludingMissingMembers());

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/PermissionModelTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/PermissionModelTests.cs
@@ -19,7 +19,7 @@ public class PermissionModelTests
         string providerName,
         long ukprn)
     {
-        var permission = new Permission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
+        var permission = new ProviderPermission { Operations = new List<Operation>(), ProviderName = providerName, Ukprn = ukprn };
         if (operation1 != null) permission.Operations.Add(operation1.Value);
         if (operation2 != null) permission.Operations.Add(operation2.Value);
 

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/SelectLegalEntitiesViewModelTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/SelectLegalEntitiesViewModelTests.cs
@@ -8,7 +8,7 @@ public class SelectLegalEntitiesViewModelTests
 {
 
     [Test, AutoData]
-    public void Operator_ConvertsTo_LegalEntityModel(List<AccountLegalEntity> legalEntities, string backLink, string cancelUrl)
+    public void Operator_ConvertsTo_LegalEntityModel(List<LegalEntity> legalEntities, string backLink, string cancelUrl)
     {
         SelectLegalEntitiesViewModel sut = new(cancelUrl, backLink);
 

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/SelectLegalEntitiesViewModelTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/SelectLegalEntitiesViewModelTests.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture.NUnit3;
-using SFA.DAS.Employer.PR.Domain.Models;
+using SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
 using SFA.DAS.Employer.PR.Web.Models;
 
 namespace SFA.DAS.Employer.PR.Web.UnitTests.Models;
@@ -8,7 +8,7 @@ public class SelectLegalEntitiesViewModelTests
 {
 
     [Test, AutoData]
-    public void Operator_ConvertsTo_LegalEntityModel(List<LegalEntity> legalEntities, string backLink, string cancelUrl)
+    public void Operator_ConvertsTo_LegalEntityModel(List<AccountLegalEntity> legalEntities, string backLink, string cancelUrl)
     {
         SelectLegalEntitiesViewModel sut = new(cancelUrl, backLink);
 

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/YourTrainingProvidersViewModelTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Models/YourTrainingProvidersViewModelTests.cs
@@ -6,7 +6,7 @@ namespace SFA.DAS.Employer.PR.Web.UnitTests.Models;
 public class YourTrainingProvidersViewModelTests
 {
     [Test, AutoData]
-    public void Operator_ConvertsTo_YourTrainingProvidersViewModel(List<AccountLegalEntity> legalEntities)
+    public void Operator_ConvertsTo_YourTrainingProvidersViewModel(List<LegalEntity> legalEntities)
     {
         YourTrainingProvidersViewModel sut = legalEntities;
         sut.LegalEntities.Should().BeEquivalentTo(legalEntities, options => options.ExcludingMissingMembers());

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Validators/SelectLegalEntitySubmitModelValidatorTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Validators/SelectLegalEntitySubmitModelValidatorTests.cs
@@ -11,13 +11,13 @@ public class SelectLegalEntitySubmitModelValidatorTests
     {
         var model = new SelectLegalEntitiesSubmitViewModel
         {
-            LegalEntityId = legalEntityId
+            LegalEntityPublicHashedId = legalEntityId
         };
 
         var sut = new SelectLegalEntitySubmitModelValidator();
         var result = sut.TestValidate(model);
 
-        result.ShouldNotHaveValidationErrorFor(c => c.LegalEntityId);
+        result.ShouldNotHaveValidationErrorFor(c => c.LegalEntityPublicHashedId);
     }
 
     [Test]
@@ -27,7 +27,7 @@ public class SelectLegalEntitySubmitModelValidatorTests
         var sut = new SelectLegalEntitySubmitModelValidator();
         var result = sut.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor(c => c.LegalEntityId)
+        result.ShouldHaveValidationErrorFor(c => c.LegalEntityPublicHashedId)
             .WithErrorMessage(SelectLegalEntitySubmitModelValidator.NoOrganisationSelectedErrorMessage);
     }
 }

--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Validators/SelectLegalEntitySubmitModelValidatorTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Validators/SelectLegalEntitySubmitModelValidatorTests.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.Employer.PR.Web.UnitTests.Validators;
 public class SelectLegalEntitySubmitModelValidatorTests
 {
     [Test, MoqAutoData]
-    public void TestValidate_LegalEntitySet_Valid(long legalEntityId)
+    public void TestValidate_LegalEntitySet_Valid(string legalEntityId)
     {
         var model = new SelectLegalEntitiesSubmitViewModel
         {

--- a/src/SFA.DAS.Employer.PR.Web/Controllers/SelectLegalEntityController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/SelectLegalEntityController.cs
@@ -27,7 +27,7 @@ public class SelectLegalEntityController(IOuterApiClient _outerApiClient, ISessi
         if (sessionModel == null)
         {
             var accountId = _encodingService.Decode(employerAccountId, EncodingType.AccountId);
-            var response = await _outerApiClient.GetAccountLegalEntities(accountId, cancellationToken);
+            var response = await _outerApiClient.GetEmployerRelationships(accountId, cancellationToken);
 
             sessionModel = new AddTrainingProvidersSessionModel
             {

--- a/src/SFA.DAS.Employer.PR.Web/Controllers/SelectLegalEntityController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/SelectLegalEntityController.cs
@@ -63,6 +63,7 @@ public class SelectLegalEntityController(IOuterApiClient _outerApiClient, ISessi
     public IActionResult Index([FromRoute] string employerAccountId, SelectLegalEntitiesSubmitViewModel submitModel)
     {
         var sessionModel = _sessionService.Get<AddTrainingProvidersSessionModel>();
+        if (sessionModel == null) return RedirectToRoute(RouteNames.YourTrainingProviders, new { employerAccountId });
 
         ValidationResult result = _validator.Validate(submitModel);
 

--- a/src/SFA.DAS.Employer.PR.Web/Controllers/SelectLegalEntityController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/SelectLegalEntityController.cs
@@ -73,7 +73,7 @@ public class SelectLegalEntityController(IOuterApiClient _outerApiClient, ISessi
             return View(ViewPath, model);
         }
 
-        SetSessionForSelectionMade(submitModel.LegalEntityId!, sessionModel);
+        SetSessionForSelectionMade(submitModel.LegalEntityPublicHashedId!, sessionModel);
         return RedirectToRoute(RouteNames.SelectTrainingProvider, new { employerAccountId });
     }
 

--- a/src/SFA.DAS.Employer.PR.Web/Controllers/SelectLegalEntityController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/SelectLegalEntityController.cs
@@ -4,6 +4,7 @@ using FluentValidation.Results;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Employer.PR.Domain.Interfaces;
+using SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
 using SFA.DAS.Employer.PR.Web.Authentication;
 using SFA.DAS.Employer.PR.Web.Infrastructure;
 using SFA.DAS.Employer.PR.Web.Infrastructure.Services;
@@ -45,12 +46,11 @@ public class SelectLegalEntityController(IOuterApiClient _outerApiClient, ISessi
 
         SelectLegalEntitiesViewModel model = GetViewModel(employerAccountId, sessionModel);
 
-        if (model.LegalEntities.Count == 1)
+        if (sessionModel.AccountLegalEntities.Count == 1)
         {
-
-            var legalEntity = model.LegalEntities[0];
-            sessionModel.SelectedLegalEntityId = _encodingService.Decode(legalEntity.Id, EncodingType.PublicAccountLegalEntityId);
-            sessionModel.SelectedLegalName = legalEntity.Name;
+            AccountLegalEntity legalEntity = sessionModel.AccountLegalEntities[0];
+            sessionModel.SelectedLegalEntityId = legalEntity.AccountLegalEntityId;
+            sessionModel.SelectedLegalName = legalEntity.AccountLegalEntityName;
             _sessionService.Set(sessionModel);
 
             return RedirectToRoute(RouteNames.SelectTrainingProvider, new { employerAccountId });

--- a/src/SFA.DAS.Employer.PR.Web/Controllers/ServiceController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/ServiceController.cs
@@ -71,7 +71,6 @@ public class ServiceController(IConfiguration _configuration, IStubAuthenticatio
     [Route("account-details", Name = RouteNames.StubAccount.DetailsPost)]
     public async Task<IActionResult> AccountDetails(StubAuthenticationViewModel model)
     {
-
         var claims = await _stubAuthenticationService.GetStubSignInClaims(model);
 
         await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, claims,
@@ -83,17 +82,18 @@ public class ServiceController(IConfiguration _configuration, IStubAuthenticatio
     [HttpGet]
     [Authorize(Policy = nameof(PolicyNames.IsAuthenticated))]
     [Route("Stub-Auth", Name = RouteNames.StubAccount.SignedIn)]
-    public IActionResult StubSignedIn()
+    public IActionResult StubSignedIn([FromQuery] string? returnUrl)
     {
 
         var employerAccounts = User.GetEmployerAccounts().Values.ToList();
 
+        string url = string.IsNullOrEmpty(returnUrl?.Trim('/')) ? Url.RouteUrl(RouteNames.Home, new { EmployerAccountId = employerAccounts[0].AccountId })! : returnUrl;
         var viewModel = new AccountStubViewModel
         {
             Email = User.FindFirstValue(ClaimTypes.Email)!,
             Id = User.FindFirstValue(ClaimTypes.NameIdentifier)!,
             Accounts = employerAccounts,
-            ReturnUrl = Url.RouteUrl(RouteNames.Home, new { EmployerAccountId = employerAccounts[0].AccountId })!
+            ReturnUrl = url
         };
 
         return View(viewModel);

--- a/src/SFA.DAS.Employer.PR.Web/Controllers/YourTrainingProvidersController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/YourTrainingProvidersController.cs
@@ -67,7 +67,7 @@ public class YourTrainingProvidersController(IOuterApiClient _outerApiClient, IS
 
             var permissions = new List<PermissionModel>();
 
-            foreach (var p in ale.ProviderPermissions.OrderBy(p => p.ProviderName))
+            foreach (var p in ale.Permissions.OrderBy(p => p.ProviderName))
             {
                 var pm = (PermissionModel)p;
                 pm.ChangePermissionsLink = Url.RouteUrl(RouteNames.ChangePermissions,

--- a/src/SFA.DAS.Employer.PR.Web/Controllers/YourTrainingProvidersController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/YourTrainingProvidersController.cs
@@ -22,7 +22,7 @@ public class YourTrainingProvidersController(IOuterApiClient _outerApiClient, IS
     {
         _sessionService.Delete<AddTrainingProvidersSessionModel>();
         var accountId = _encodingService.Decode(employerAccountId, EncodingType.AccountId);
-        var response = await _outerApiClient.GetAccountLegalEntities(accountId, cancellationToken);
+        var response = await _outerApiClient.GetEmployerRelationships(accountId, cancellationToken);
         var accountLegalEntities = response.AccountLegalEntities.OrderBy(a => a.Name);
 
         var legalEntityModels = OrderPermissionsAndAddLinks(employerAccountId, accountLegalEntities);
@@ -57,7 +57,7 @@ public class YourTrainingProvidersController(IOuterApiClient _outerApiClient, IS
         }
     }
 
-    private List<LegalEntityModel> OrderPermissionsAndAddLinks(string employerAccountId, IOrderedEnumerable<AccountLegalEntity> accountLegalEntities)
+    private List<LegalEntityModel> OrderPermissionsAndAddLinks(string employerAccountId, IOrderedEnumerable<LegalEntity> accountLegalEntities)
     {
         var legalEntityModels = new List<LegalEntityModel>();
 
@@ -67,7 +67,7 @@ public class YourTrainingProvidersController(IOuterApiClient _outerApiClient, IS
 
             var permissions = new List<PermissionModel>();
 
-            foreach (var p in ale.Permissions.OrderBy(p => p.ProviderName))
+            foreach (var p in ale.ProviderPermissions.OrderBy(p => p.ProviderName))
             {
                 var pm = (PermissionModel)p;
                 pm.ChangePermissionsLink = Url.RouteUrl(RouteNames.ChangePermissions,

--- a/src/SFA.DAS.Employer.PR.Web/Infrastructure/Services/ISessionService.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Infrastructure/Services/ISessionService.cs
@@ -5,7 +5,7 @@ public interface ISessionService
     void Set(string key, string value);
     void Set<T>(T model);
     string? Get(string key);
-    T Get<T>();
+    T? Get<T>();
     void Delete(string key);
     void Delete<T>();
     void Clear();

--- a/src/SFA.DAS.Employer.PR.Web/Infrastructure/Services/SessionService.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Infrastructure/Services/SessionService.cs
@@ -11,10 +11,10 @@ public class SessionService(IHttpContextAccessor _httpContextAccessor) : ISessio
 
     public string? Get(string key) => _httpContextAccessor.HttpContext?.Session.GetString(key);
 
-    public T Get<T>()
+    public T? Get<T>()
     {
         var json = Get(typeof(T).Name);
-        return (string.IsNullOrEmpty(json) ? default : JsonSerializer.Deserialize<T>(json))!;
+        return (string.IsNullOrEmpty(json) ? default : JsonSerializer.Deserialize<T>(json));
     }
 
     public void Delete(string key)

--- a/src/SFA.DAS.Employer.PR.Web/Models/AccountLegalEntityViewModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/AccountLegalEntityViewModel.cs
@@ -1,0 +1,10 @@
+﻿using SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
+
+namespace SFA.DAS.Employer.PR.Web.Models;
+
+public record AccountLegalEntityViewModel(string Id, string Name)
+{
+    public bool IsSelected { get; set; }
+    public static implicit operator AccountLegalEntityViewModel(AccountLegalEntity source)
+        => new(source.AccountLegalEntityPublicHashedId, source.AccountLegalEntityName);
+}

--- a/src/SFA.DAS.Employer.PR.Web/Models/LegalEntityModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/LegalEntityModel.cs
@@ -13,7 +13,7 @@ public class LegalEntityModel
 
     public List<PermissionModel> Permissions { get; set; } = new();
 
-    public static implicit operator LegalEntityModel(AccountLegalEntity legalEntity)
+    public static implicit operator LegalEntityModel(LegalEntity legalEntity)
     {
         var model = new LegalEntityModel
         {
@@ -23,7 +23,7 @@ public class LegalEntityModel
             Name = legalEntity.Name
         };
 
-        foreach (var permission in legalEntity.Permissions)
+        foreach (var permission in legalEntity.ProviderPermissions)
         {
             model.Permissions.Add(permission);
         }

--- a/src/SFA.DAS.Employer.PR.Web/Models/LegalEntityModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/LegalEntityModel.cs
@@ -23,7 +23,7 @@ public class LegalEntityModel
             Name = legalEntity.Name
         };
 
-        foreach (var permission in legalEntity.ProviderPermissions)
+        foreach (var permission in legalEntity.Permissions)
         {
             model.Permissions.Add(permission);
         }

--- a/src/SFA.DAS.Employer.PR.Web/Models/PermissionModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/PermissionModel.cs
@@ -15,7 +15,7 @@ public class PermissionModel
     public string PermissionToAddRecords { get; set; } = null!;
     public string PermissionToRecruitApprentices { get; set; } = null!;
 
-    public static implicit operator PermissionModel(Permission permission)
+    public static implicit operator PermissionModel(ProviderPermission permission)
     {
         var model = new PermissionModel
         {

--- a/src/SFA.DAS.Employer.PR.Web/Models/SelectLegalEntitiesViewModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/SelectLegalEntitiesViewModel.cs
@@ -1,8 +1,10 @@
-﻿namespace SFA.DAS.Employer.PR.Web.Models;
+﻿using SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
+
+namespace SFA.DAS.Employer.PR.Web.Models;
 
 public class SelectLegalEntitiesViewModel : SelectLegalEntitiesSubmitViewModel
 {
-    public List<LegalEntityModel> LegalEntities { get; set; } = new();
+    public List<AccountLegalEntityViewModel> LegalEntities { get; set; } = new();
     public string BackLink { get; set; }
 
     public SelectLegalEntitiesViewModel(string cancelUrl, string backLink)
@@ -11,8 +13,15 @@ public class SelectLegalEntitiesViewModel : SelectLegalEntitiesSubmitViewModel
     }
 }
 
+public record AccountLegalEntityViewModel(string Id, string Name)
+{
+    public bool IsSelected { get; set; }
+    public static implicit operator AccountLegalEntityViewModel(AccountLegalEntity source)
+        => new(source.AccountLegalEntityPublicHashedId, source.AccountLegalEntityName);
+}
+
 public class SelectLegalEntitiesSubmitViewModel
 {
-    public long? LegalEntityId { get; set; }
+    public string? LegalEntityId { get; set; }
     public string? LegalName { get; set; }
 }

--- a/src/SFA.DAS.Employer.PR.Web/Models/SelectLegalEntitiesViewModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/SelectLegalEntitiesViewModel.cs
@@ -23,5 +23,4 @@ public record AccountLegalEntityViewModel(string Id, string Name)
 public class SelectLegalEntitiesSubmitViewModel
 {
     public string? LegalEntityPublicHashedId { get; set; }
-    public string? LegalName { get; set; }
 }

--- a/src/SFA.DAS.Employer.PR.Web/Models/SelectLegalEntitiesViewModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/SelectLegalEntitiesViewModel.cs
@@ -1,6 +1,4 @@
-﻿using SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
-
-namespace SFA.DAS.Employer.PR.Web.Models;
+﻿namespace SFA.DAS.Employer.PR.Web.Models;
 
 public class SelectLegalEntitiesViewModel : SelectLegalEntitiesSubmitViewModel
 {
@@ -11,13 +9,6 @@ public class SelectLegalEntitiesViewModel : SelectLegalEntitiesSubmitViewModel
     {
         BackLink = backLink;
     }
-}
-
-public record AccountLegalEntityViewModel(string Id, string Name)
-{
-    public bool IsSelected { get; set; }
-    public static implicit operator AccountLegalEntityViewModel(AccountLegalEntity source)
-        => new(source.AccountLegalEntityPublicHashedId, source.AccountLegalEntityName);
 }
 
 public class SelectLegalEntitiesSubmitViewModel

--- a/src/SFA.DAS.Employer.PR.Web/Models/SelectLegalEntitiesViewModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/SelectLegalEntitiesViewModel.cs
@@ -22,6 +22,6 @@ public record AccountLegalEntityViewModel(string Id, string Name)
 
 public class SelectLegalEntitiesSubmitViewModel
 {
-    public string? LegalEntityId { get; set; }
+    public string? LegalEntityPublicHashedId { get; set; }
     public string? LegalName { get; set; }
 }

--- a/src/SFA.DAS.Employer.PR.Web/Models/Session/AddTrainingProvidersSessionModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/Session/AddTrainingProvidersSessionModel.cs
@@ -10,7 +10,7 @@ public class AddTrainingProvidersSessionModel
     public string? ProviderName { get; set; }
     public long? Ukprn { get; set; }
 
-    public List<AccountLegalEntity> AccountLegalEntities { get; set; } = [];
+    public List<LegalEntity> AccountLegalEntities { get; set; } = [];
     public string? PermissionToAddCohorts { get; set; }
     public string? PermissionToRecruit { get; set; }
 

--- a/src/SFA.DAS.Employer.PR.Web/Models/Session/AddTrainingProvidersSessionModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/Session/AddTrainingProvidersSessionModel.cs
@@ -1,4 +1,4 @@
-﻿using SFA.DAS.Employer.PR.Domain.Models;
+﻿using SFA.DAS.Employer.PR.Domain.OuterApi.Responses;
 
 namespace SFA.DAS.Employer.PR.Web.Models.Session;
 
@@ -10,7 +10,7 @@ public class AddTrainingProvidersSessionModel
     public string? ProviderName { get; set; }
     public long? Ukprn { get; set; }
 
-    public List<LegalEntity> AccountLegalEntities { get; set; } = [];
+    public List<AccountLegalEntity> AccountLegalEntities { get; set; } = [];
     public string? PermissionToAddCohorts { get; set; }
     public string? PermissionToRecruit { get; set; }
 

--- a/src/SFA.DAS.Employer.PR.Web/Models/YourTrainingProvidersViewModel.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Models/YourTrainingProvidersViewModel.cs
@@ -12,7 +12,7 @@ public class YourTrainingProvidersViewModel
     public List<LegalEntityModel> LegalEntities { get; set; } = [];
     public string AddTrainingProviderUrl { get; set; } = null!;
 
-    public static implicit operator YourTrainingProvidersViewModel(List<AccountLegalEntity> legalEntities)
+    public static implicit operator YourTrainingProvidersViewModel(List<LegalEntity> legalEntities)
     {
         var model = new YourTrainingProvidersViewModel();
         foreach (var legalEntity in legalEntities)

--- a/src/SFA.DAS.Employer.PR.Web/Validators/SelectLegalEntitySubmitModelValidator.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Validators/SelectLegalEntitySubmitModelValidator.cs
@@ -9,7 +9,7 @@ public class SelectLegalEntitySubmitModelValidator : AbstractValidator<SelectLeg
 
     public SelectLegalEntitySubmitModelValidator()
     {
-        RuleFor(s => s.LegalEntityId)
+        RuleFor(s => s.LegalEntityPublicHashedId)
             .NotEmpty()
             .WithMessage(NoOrganisationSelectedErrorMessage);
     }

--- a/src/SFA.DAS.Employer.PR.Web/Views/SelectLegalEntity/Index.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/SelectLegalEntity/Index.cshtml
@@ -30,7 +30,7 @@
                             {
                                 <div class="govuk-radios__item">
                                     <input class="govuk-radios__input" id="legalEntity-{@index}" name="legalEntityId"
-                                        type="radio" value="@legalEntitiesOrdered[index].LegalEntityId"
+                                        type="radio" value="@legalEntitiesOrdered[index].Id"
                                         Checked="@legalEntitiesOrdered[index].IsSelected">
                                     <label class="govuk-label govuk-radios__label" for="legalEntity-{@index}">
                                         @legalEntitiesOrdered[index].Name

--- a/src/SFA.DAS.Employer.PR.Web/Views/SelectLegalEntity/Index.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/SelectLegalEntity/Index.cshtml
@@ -22,9 +22,9 @@
                     <p class="govuk-body">
                         You have multiple organisations on your account. Select one organisation to add a training provider to.
                     </p>
-                    <div class="govuk-form-group" id="LegalEntityId" esfa-validation-marker-for="@Model.LegalEntityId">
+                    <div class="govuk-form-group" id="LegalEntityId" esfa-validation-marker-for="@Model.LegalEntityPublicHashedId">
 
-                        <span asp-validation-for="LegalEntityId" class="govuk-error-message"></span>
+                        <span asp-validation-for="LegalEntityPublicHashedId" class="govuk-error-message"></span>
                         <div class="govuk-radios" data-module="govuk-radios">
                             @for (var index = 0; index < legalEntitiesOrdered.Count; index++)
                             {

--- a/src/SFA.DAS.Employer.PR.Web/Views/SelectLegalEntity/Index.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/SelectLegalEntity/Index.cshtml
@@ -22,14 +22,14 @@
                     <p class="govuk-body">
                         You have multiple organisations on your account. Select one organisation to add a training provider to.
                     </p>
-                    <div class="govuk-form-group" id="LegalEntityId" esfa-validation-marker-for="@Model.LegalEntityPublicHashedId">
+                    <div class="govuk-form-group" id="LegalEntityPublicHashedId" esfa-validation-marker-for="@Model.LegalEntityPublicHashedId">
 
                         <span asp-validation-for="LegalEntityPublicHashedId" class="govuk-error-message"></span>
                         <div class="govuk-radios" data-module="govuk-radios">
                             @for (var index = 0; index < legalEntitiesOrdered.Count; index++)
                             {
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="legalEntity-{@index}" name="legalEntityId"
+                                    <input class="govuk-radios__input" id="legalEntity-{@index}" name="LegalEntityPublicHashedId"
                                         type="radio" value="@legalEntitiesOrdered[index].Id"
                                         Checked="@legalEntitiesOrdered[index].IsSelected">
                                     <label class="govuk-label govuk-radios__label" for="legalEntity-{@index}">

--- a/src/SFA.DAS.Employer.PR.Web/Views/Service/StubSignedIn.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/Service/StubSignedIn.cshtml
@@ -1,4 +1,5 @@
 @using System.Security.Claims
+@using SFA.DAS.Employer.PR.Web.Infrastructure
 @using SFA.DAS.Employer.PR.Web.Models.StubAuth
 
 @model AccountStubViewModel
@@ -23,7 +24,7 @@
             @foreach (var account in Model.Accounts)
             {
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">@account.AccountId</td>
+                        <td class="govuk-table__cell"><a href="@Url.RouteUrl(RouteNames.Home, new { EmployerAccountId = account.AccountId})"> @account.AccountId</a></td>
                     <td class="govuk-table__cell">@account.Role</td>
                     <td class="govuk-table__cell">@account.EmployerName</td>
                 </tr>


### PR DESCRIPTION
Now correctly using outer `employeraccounts/{accountId}/LegalEntities` endpoint. 
The radios on select legal entity page are updated to hold hashed id in the value attribute instead of clear numerical id