### PR TITLE
CSP-1705: Incorrect banner showing when declining add account request

### DIFF
--- a/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/DeclineAddAccountConfirmationControllerTests.cs
+++ b/src/SFA.DAS.Employer.PR.Web.UnitTests/Controllers/DeclineAddAccountConfirmationControllerTests.cs
@@ -142,6 +142,7 @@ public sealed class DeclineAddAccountConfirmationControllerTests
             var redirectResult = result as RedirectToRouteResult;
             Assert.That(redirectResult, Is.Not.Null);
             Assert.That(RouteNames.YourTrainingProviders, Is.EqualTo(redirectResult?.RouteName)!);
+            Assert.That(_controller.TempData.Count, Is.EqualTo(0));
         });
     }
 }

--- a/src/SFA.DAS.Employer.PR.Web/Controllers/DeclineAddAccountConfirmationController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/DeclineAddAccountConfirmationController.cs
@@ -27,6 +27,7 @@ public sealed class DeclineAddAccountConfirmationController(IOuterApiClient _out
 
         if(requestDeclinedConfirmation is null || requestDeclinedConfirmation.Value != requestId)
         {
+            TempData.Clear();
             return RedirectToRoute(RouteNames.YourTrainingProviders, new { employerAccountId });
         }
 


### PR DESCRIPTION
- BUG: When refreshing the page to return to manage your training providers, an additional page refresh shows the updated permissions banner due to over staying temporary data.