### PR TITLE
CSP-1812: PR (Employer-Led) - Screen Reader Analysis

### DIFF
--- a/src/SFA.DAS.Employer.PR.Web/Controllers/ChangePermissionsController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/ChangePermissionsController.cs
@@ -40,6 +40,7 @@ public class ChangePermissionsController(IOuterApiClient _outerApiClient, IEncod
     public async Task<IActionResult> Index([FromRoute] string employerAccountId,
         ChangePermissionsSubmitModel submitViewModel, CancellationToken cancellationToken)
     {
+        
         var model = await GetViewModel(employerAccountId, submitViewModel.LegalEntityId, submitViewModel.Ukprn, cancellationToken);
 
         if (model == null)

--- a/src/SFA.DAS.Employer.PR.Web/Controllers/ChangePermissionsController.cs
+++ b/src/SFA.DAS.Employer.PR.Web/Controllers/ChangePermissionsController.cs
@@ -40,7 +40,6 @@ public class ChangePermissionsController(IOuterApiClient _outerApiClient, IEncod
     public async Task<IActionResult> Index([FromRoute] string employerAccountId,
         ChangePermissionsSubmitModel submitViewModel, CancellationToken cancellationToken)
     {
-        
         var model = await GetViewModel(employerAccountId, submitViewModel.LegalEntityId, submitViewModel.Ukprn, cancellationToken);
 
         if (model == null)

--- a/src/SFA.DAS.Employer.PR.Web/Views/ChangePermissions/Index.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/ChangePermissions/Index.cshtml
@@ -18,8 +18,6 @@
                     Set permissions for @Model.ProviderName.ToUpper()
                 </h1>
                 <input asp-for="LegalEntityId" id="legalEntityId" type="hidden" />
-                @* <input asp-for="LegalName" id="legalName" type="hidden" /> *@
-                @* <input asp-for="ProviderName" id="providerName" type="hidden" /> *@
                 <input asp-for="Ukprn" id="ukprn" type="hidden" />
                 <input asp-for="PermissionToAddCohortsOriginal" id="AddRecordsOriginal" type="hidden" />
                 <input asp-for="PermissionToRecruitOriginal" id="RecruitApprenticesOriginal" type="hidden" />

--- a/src/SFA.DAS.Employer.PR.Web/Views/ChangePermissions/Index.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/ChangePermissions/Index.cshtml
@@ -14,23 +14,19 @@
         <partial name="_validationSummary" />
         <form asp-route="@RouteNames.ChangePermissions" method="POST">
             <div class="govuk-form-group">
-                <fieldset class="govuk-fieldset">
-                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                        <h1 class="govuk-fieldset__heading">
-                            Set permissions for @Model.ProviderName.ToUpper()
-                        </h1>
-                    </legend>
-                    <input asp-for="LegalEntityId" id="legalEntityId" type="hidden" />
-                    @* <input asp-for="LegalName" id="legalName" type="hidden" /> *@
-                    @* <input asp-for="ProviderName" id="providerName" type="hidden" /> *@
-                    <input asp-for="Ukprn" id="ukprn" type="hidden" />
-                    <input asp-for="PermissionToAddCohortsOriginal" id="AddRecordsOriginal" type="hidden" />
-                    <input asp-for="PermissionToRecruitOriginal" id="RecruitApprenticesOriginal" type="hidden" />
-                    <p class="govuk-body">
-                        Select what permissions you want this training provider to have for @(Model.LegalName.ToUpper()). You can change these permissions at any time.
-                    </p>
-                    <partial name="_PermissionChoices" />
-                </fieldset>
+                <h1 class="govuk-heading-l">
+                    Set permissions for @Model.ProviderName.ToUpper()
+                </h1>
+                <input asp-for="LegalEntityId" id="legalEntityId" type="hidden" />
+                @* <input asp-for="LegalName" id="legalName" type="hidden" /> *@
+                @* <input asp-for="ProviderName" id="providerName" type="hidden" /> *@
+                <input asp-for="Ukprn" id="ukprn" type="hidden" />
+                <input asp-for="PermissionToAddCohortsOriginal" id="AddRecordsOriginal" type="hidden" />
+                <input asp-for="PermissionToRecruitOriginal" id="RecruitApprenticesOriginal" type="hidden" />
+                <p class="govuk-body">
+                    Select what permissions you want this training provider to have for @(Model.LegalName.ToUpper()). You can change these permissions at any time.
+                </p>
+                <partial name="_PermissionChoices" />
             </div>
             <div class="govuk-button-group">
                 <button type="submit" id="continue" class="govuk-button" data-disable-on-submit="true">Confirm</button>

--- a/src/SFA.DAS.Employer.PR.Web/Views/Shared/_PermissionChoices.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/Shared/_PermissionChoices.cshtml
@@ -3,56 +3,62 @@
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model SFA.DAS.Employer.PR.Web.Models.PermissionDescriptionsModel
 <br/><br/>
-<legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-    Add apprentice records
-</legend>
-<div id="addRecords-hint" class="govuk-hint">
-    Training provider can add details of new apprentices and reserve funding for them if needed. Apprentice records will not be added to your account until you approve them.
-</div>
-<div esfa-validation-marker-for="@Model.PermissionToAddCohorts" class="govuk-form-group">
-    <span asp-validation-for="PermissionToAddCohorts" class="govuk-error-message"></span>
-    <div class="govuk-radios" id="PermissionToAddCohorts" data-module="govuk-radios">
-        <div class="govuk-radios__item">
-            <input asp-for="PermissionToAddCohorts" class="govuk-radios__input" id="addRecords-1" type="radio" value="@OperationsMappingService.Yes">
-            <label class="govuk-label govuk-radios__label" for="addRecords-1">
-                Yes, but I want final review of apprentice records
-            </label>
-        </div>
-        <div class="govuk-radios__item">
-            <input asp-for="PermissionToAddCohorts" class="govuk-radios__input" id="addRecords-2" type="radio" value="@OperationsMappingService.No">
-            <label class="govuk-label govuk-radios__label" for="addRecords-2">
-                No
-            </label>
+
+<fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        Add apprentice records
+    </legend>
+    <div id="addRecords-hint" class="govuk-hint">
+        Training provider can add details of new apprentices and reserve funding for them if needed. Apprentice records will not be added to your account until you approve them.
+    </div>
+    <div esfa-validation-marker-for="@Model.PermissionToAddCohorts" class="govuk-form-group">
+        <span asp-validation-for="PermissionToAddCohorts" class="govuk-error-message"></span>
+        <div class="govuk-radios" id="PermissionToAddCohorts" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+                <input asp-for="PermissionToAddCohorts" class="govuk-radios__input" id="addRecords-1" type="radio" value="@OperationsMappingService.Yes">
+                <label class="govuk-label govuk-radios__label" for="addRecords-1">
+                    Yes, but I want final review of apprentice records
+                </label>
+            </div>
+            <div class="govuk-radios__item">
+                <input asp-for="PermissionToAddCohorts" class="govuk-radios__input" id="addRecords-2" type="radio" value="@OperationsMappingService.No">
+                <label class="govuk-label govuk-radios__label" for="addRecords-2">
+                    No
+                </label>
+            </div>
         </div>
     </div>
-</div>
+</fieldset>
 <br />
-<legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-    Recruit apprentices
-</legend>
-<div id="recruitApprentices-hint" class="govuk-hint">
-    Training provider can advertise apprenticeships and review applications on your behalf.
-</div>
-<div esfa-validation-marker-for="@Model.PermissionToRecruit" class="govuk-form-group">
-    <span asp-validation-for="PermissionToRecruit" class="govuk-error-message"></span>
-    <div class="govuk-radios" id="PermissionToRecruit" data-module="govuk-radios">
-        <div class="govuk-radios__item">
-            <input asp-for="PermissionToRecruit" class="govuk-radios__input" id="recruitApprentices-1" type="radio" value="@OperationsMappingService.Yes">
-            <label class="govuk-label govuk-radios__label" for="recruitApprentices-1">
-                Yes
-            </label>
-        </div>
-        <div class="govuk-radios__item">
-            <input asp-for="PermissionToRecruit" class="govuk-radios__input" id="recruitApprentices-2" type="radio" value="@OperationsMappingService.YesWithReview">
-            <label class="govuk-label govuk-radios__label" for="recruitApprentices-2">
-                Yes, but I want to review adverts before they're advertised
-            </label>
-        </div>
-        <div class="govuk-radios__item">
-            <input asp-for="PermissionToRecruit" class="govuk-radios__input" id="recruitApprentices-3" type="radio" value="@OperationsMappingService.No">
-            <label class="govuk-label govuk-radios__label" for="recruitApprentices-3">
-                No
-            </label>
+
+<fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        Recruit apprentices
+    </legend>
+    <div id="recruitApprentices-hint" class="govuk-hint">
+        Training provider can advertise apprenticeships and review applications on your behalf.
+    </div>
+    <div esfa-validation-marker-for="@Model.PermissionToRecruit" class="govuk-form-group">
+        <span asp-validation-for="PermissionToRecruit" class="govuk-error-message"></span>
+        <div class="govuk-radios" id="PermissionToRecruit" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+                <input asp-for="PermissionToRecruit" class="govuk-radios__input" id="recruitApprentices-1" type="radio" value="@OperationsMappingService.Yes">
+                <label class="govuk-label govuk-radios__label" for="recruitApprentices-1">
+                    Yes
+                </label>
+            </div>
+            <div class="govuk-radios__item">
+                <input asp-for="PermissionToRecruit" class="govuk-radios__input" id="recruitApprentices-2" type="radio" value="@OperationsMappingService.YesWithReview">
+                <label class="govuk-label govuk-radios__label" for="recruitApprentices-2">
+                    Yes, but I want to review adverts before they're advertised
+                </label>
+            </div>
+            <div class="govuk-radios__item">
+                <input asp-for="PermissionToRecruit" class="govuk-radios__input" id="recruitApprentices-3" type="radio" value="@OperationsMappingService.No">
+                <label class="govuk-label govuk-radios__label" for="recruitApprentices-3">
+                    No
+                </label>
+            </div>
         </div>
     </div>
-</div>
+</fieldset>

--- a/src/SFA.DAS.Employer.PR.Web/Views/YourTrainingProviders/Index.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/YourTrainingProviders/Index.cshtml
@@ -89,7 +89,7 @@
                     @if (@Model.IsOwner && permissionDetails.HasOutstandingRequest)
                     {
                         <tr class="govuk-table__row">
-                            <td class="govuk-table__cell govuk-!-padding-bottom-0 govuk-!-padding-top-3 border-bottom-override" colspan="4">
+                            <td scope="row" class="govuk-table__cell govuk-!-padding-bottom-0 govuk-!-padding-top-3 border-bottom-override" colspan="4">
                                 <strong class="govuk-tag govuk-tag--orange">
                                     Request pending
                                 </strong>
@@ -97,12 +97,12 @@
                         </tr>
                     }
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell govuk-!-padding-bottom-4">@permissionDetails.ProviderName.ToUpper()</td>
-                        <td class="govuk-table__cell govuk-!-padding-bottom-4">@permissionDetails.PermissionToAddRecords</td>
-                        <td class="govuk-table__cell govuk-!-padding-bottom-4">@permissionDetails.PermissionToRecruitApprentices</td>
+                        <td headers="training-provider" class="govuk-table__cell govuk-!-padding-bottom-4">@permissionDetails.ProviderName.ToUpper()</td>
+                        <td headers="add-records" class="govuk-table__cell govuk-!-padding-bottom-4">@permissionDetails.PermissionToAddRecords</td>
+                        <td headers="recruit-apprentices" class="govuk-table__cell govuk-!-padding-bottom-4">@permissionDetails.PermissionToRecruitApprentices</td>
                         @if (@Model.IsOwner)
                         {
-                            <td class="govuk-table__cell"><a class="govuk-link" href="@permissionDetails.ActionLink">@permissionDetails.ActionLinkText</a></td>
+                            <td headers="permissions" class="govuk-table__cell"><a class="govuk-link" href="@permissionDetails.ActionLink">@permissionDetails.ActionLinkText</a></td>
                         }
                     </tr>
                 }

--- a/src/SFA.DAS.Employer.PR.Web/Views/YourTrainingProviders/Index.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/YourTrainingProviders/Index.cshtml
@@ -74,12 +74,12 @@
         <table class="govuk-table">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header govuk-!-width-one-third">Training provider</th>
-                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Permission to add apprentice records</th>
-                    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Permission to recruit apprentices</th>
+                    <th id="training-provider" scope="col" class="govuk-table__header govuk-!-width-one-third">Training provider</th>
+                    <th id="add-records" scope="col" class="govuk-table__header govuk-!-width-one-quarter">Permission to add apprentice records</th>
+                    <th id="recruit-apprentices" scope="col" class="govuk-table__header govuk-!-width-one-quarter">Permission to recruit apprentices</th>
                     @if (@Model.IsOwner)
                     {
-                        <th scope="col" class="govuk-table__header">Permissions</th>
+                        <th id="permissions" scope="col" class="govuk-table__header">Permissions</th>
                     }
                 </tr>
             </thead>
@@ -89,7 +89,7 @@
                     @if (@Model.IsOwner && permissionDetails.HasOutstandingRequest)
                     {
                         <tr class="govuk-table__row">
-                            <td scope="row" class="govuk-table__cell govuk-!-padding-bottom-0 govuk-!-padding-top-3 border-bottom-override" colspan="4">
+                            <td class="govuk-table__cell govuk-!-padding-bottom-0 govuk-!-padding-top-3 border-bottom-override" colspan="4">
                                 <strong class="govuk-tag govuk-tag--orange">
                                     Request pending
                                 </strong>

--- a/src/SFA.DAS.Employer.PR.Web/Views/YourTrainingProviders/Index.cshtml
+++ b/src/SFA.DAS.Employer.PR.Web/Views/YourTrainingProviders/Index.cshtml
@@ -8,7 +8,7 @@
         {
             <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
                 <div class="govuk-notification-banner__header">
-                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title" aria-live="polite">
                         Success
                     </h2>
                 </div>


### PR DESCRIPTION
- Update **_PermissionChoices.cshtml** partial to explicitly call out multiple field sets removing issue where screen reader was group multiple questions together as one group.

-  Updated the manage your training providers table to comply with WCAG 2.1 standards. Added explicit heading descriptions to provide more clarity to screen readers on the information contained in each cell.

- Added the aria-live attribute to the success banner on the manage your training providers page to explicitly call out to screen readers that a successful update has taken place on page load. ref https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live